### PR TITLE
Update option checking more suitable for latest middleman

### DIFF
--- a/lib/middleman-s3_redirect/commands.rb
+++ b/lib/middleman-s3_redirect/commands.rb
@@ -17,8 +17,8 @@ module Middleman
       desc "s3_redirect", "Creates redirect objects directly in S3."
       def s3_redirect
         shared_inst = ::Middleman::Application.server.inst
-        bucket = shared_inst.options.bucket
-        if (!bucket)
+        if (!shared_inst.respond_to?('s3_redirect_options') ||
+            !shared_inst.s3_redirect_options.bucket)
           raise Thor::Error.new "You need to activate this extension."
         end
 

--- a/lib/middleman-s3_redirect/extension.rb
+++ b/lib/middleman-s3_redirect/extension.rb
@@ -98,6 +98,10 @@ module Middleman
         def redirect(from, to)
           ::Middleman::S3Redirect.options.redirect(from, to)
         end
+
+        def s3_redirect_options
+          ::Middleman::S3Redirect.options
+        end
       end
     end
   end


### PR DESCRIPTION
Hi,

Thank you for useful extension.

Current master code is crashes when call s3_redirect command with middleman 3.0.13.

``` shell
$ middleman s3_redirect
== LiveReload is waiting for a browser to connect
/Users/juno/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/middleman-s3_redirect-3.0.0/lib/middleman-s3_redirect/commands.rb:20:in `s3_redirect': undefined method `options' for #<Middleman::Application::MiddlemanApplication1:0x007ff9dbe3a058> (NoMethodError)
```

I fixed this problem.
Would you like to merge this PR and release new gem?

Thanks
