### PR TITLE
Remove unused parallel dependency

### DIFF
--- a/lib/middleman-s3_redirect.rb
+++ b/lib/middleman-s3_redirect.rb
@@ -1,6 +1,5 @@
 require 'middleman-core'
 require 'fog'
-require 'parallel'
 require 'middleman-s3_redirect/version'
 require 'middleman-s3_redirect/commands'
 


### PR DESCRIPTION
It’s me again...
Thank you for quick releasing a new gem.

`middleman-s3_redirect.rb` requires the `parallel` but it does not seem to use `parallel.gem`.

Thanks,
