### PR TITLE
Fix gem name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install middleman-s3_sync
+    $ gem install middleman-s3_redirect
 
 ## Usage
 


### PR DESCRIPTION
This still said "s3_sync", probably because of missing the change after copy/paste from that gem.
