### PR TITLE
Fix bug causing truncation of source paths.

### DIFF
--- a/lib/middleman-s3_redirect/extension.rb
+++ b/lib/middleman-s3_redirect/extension.rb
@@ -57,8 +57,7 @@ module Middleman
             path << '/' unless path =~ /\/$/
             path << 'index.html'
           end
-          path = path[1..path.length] if path[0] = '/'
-          path
+          path.sub(/^\//, '')
         end
       end
 


### PR DESCRIPTION
Steps to reproduce:

``` ruby
redirect 'abc', 'http://example.com'
```

Result:

``` console
Redirecting /bc/index.html to http://example.com
```
