### PR TITLE
`redirect` helper is mutating arguments

### DIFF
--- a/lib/middleman-s3_redirect/extension.rb
+++ b/lib/middleman-s3_redirect/extension.rb
@@ -56,11 +56,7 @@ module Middleman
 
         protected
         def normalize(path)
-          unless path =~ /\.html$/
-            path << '/' unless path =~ /\/$/
-            path << 'index.html'
-          end
-          path.sub(/^\//, '')
+          path.sub(/\/?$/, '/index.html').sub(/^\//, '')
         end
       end
 


### PR DESCRIPTION
This change I'm less sure about. For the sake of semantics I [redirected `http_prefix`](https://github.com/AndrewKvalheim/opt.outof.link/blob/c0f0262acc77f8a911d354e5194c0facd75a14ed/config.rb#L22) instead of `'/'`, but the extension's path normalization actually changed that setting.

Would you consider this to be a bug in the extension, or should I just be duplicating the setting before I pass it in?
