### PR TITLE
Don't wrap directoryless path's in directories.

### DIFF
--- a/lib/middleman-s3_redirect/extension.rb
+++ b/lib/middleman-s3_redirect/extension.rb
@@ -56,10 +56,10 @@ module Middleman
 
         protected
         def normalize(path)
-          unless path =~ /\.html$/
-            path << '/' unless path =~ /\/$/
-            path << 'index.html'
-          end
+          # paths without a slash are preserved as is: e.g. path => path, or path.html => path.html
+          # paths with a slash get an index.html: e.g. path/ => path/index.html
+          # paths with a preceding slash, have the preceding slash removed
+          path << 'index.html' if path =~ /\/$/
           path.sub(/^\//, '')
         end
       end


### PR DESCRIPTION
The existing path normalization turns redirect paths into directories if they don't end with `.html`. This causes problems when the path I want to redirect from is not a `.html`.

This PR means it only ever appends to the path given if the path is explicitly a directory (ends with a slash). In this instance it appends `index.html`. In all other cases the tail of the path is left untouched.

I'm using this for http://dev.greatstoriesofthebible.org/jesus_crucifixion_by_mathew. The redirect occurs on that path without needing to involve directories. It redirects to http://dev.greatstoriesofthebible.org/jesus_crucifixion_by_matthew.
