### PR TITLE
Limit fog dependency to fog-aws

### DIFF
--- a/lib/middleman-s3_redirect.rb
+++ b/lib/middleman-s3_redirect.rb
@@ -1,5 +1,5 @@
 require 'middleman-core'
-require 'fog'
+require 'fog/aws'
 require 'middleman-s3_redirect/version'
 require 'middleman-s3_redirect/commands'
 

--- a/middleman-s3_redirect.gemspec
+++ b/middleman-s3_redirect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
 
   gem.add_runtime_dependency 'middleman-core', '>= 3.0.0'
-  gem.add_runtime_dependency 'fog', '>= 1.25.0'
+  gem.add_runtime_dependency 'fog-aws'
   gem.add_runtime_dependency 'parallel'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Hi, the top-level fog gem pulls in all of the cloud providers it supports.  We only need fog-aws here.
